### PR TITLE
Use correct git ref in rockspec file

### DIFF
--- a/kong-plugin-jwt-keycloak-1.3.0-1.rockspec
+++ b/kong-plugin-jwt-keycloak-1.3.0-1.rockspec
@@ -5,7 +5,7 @@ local rockspec_revision = "1"
 
 local github_account_name = "telekom-digioss"
 local github_repo_name = package_name
-local git_checkout = package_version == "dev" and "master" or package_version
+local git_checkout = package_version == "dev" and "master" or "v" .. package_version
 
 
 package = package_name


### PR DESCRIPTION
When trying to build our kong container for plugin version 1.3.0 I noticed it tries to clone the git ref `1.3.0` but the tag is called `v1.3.0`. This change fixes that when building with the rockspec file.