### PR TITLE
fix jwt_decoder:base64_decode after breaking change in kong 3.5.0

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -12,6 +12,7 @@ local validate_realm_roles = require("kong.plugins.jwt-keycloak.validators.roles
 local validate_client_roles = require("kong.plugins.jwt-keycloak.validators.roles").validate_client_roles
 
 local re_gmatch = ngx.re.gmatch
+local decode_base64 = ngx.decode_base64
 
 local priority_env_var = "JWT_KEYCLOAK_PRIORITY"
 local priority
@@ -26,6 +27,21 @@ local JwtKeycloakHandler = {
   VERSION = kong_meta.version,
   PRIORITY = priority,
 }
+
+-------------------------------------------------------------------------------
+-- custom helper function of the extended plugin "jwt-keycloak"
+-- --> this is contained in jwt_parser, but has a breaking change in 3.5
+-------------------------------------------------------------------------------
+local function custom_base64_decode(input)
+  local remainder = #input % 4
+  if remainder > 0 then
+    local padlen = 4 - remainder
+    input = input .. rep("=", padlen)
+  end
+
+  input = input:gsub("-", "+"):gsub("_", "/")
+  return decode_base64(input)
+end
 
 -------------------------------------------------------------------------------
 -- custom helper function of the extended plugin "jwt-keycloak"

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -85,7 +85,7 @@ local function custom_helper_issuer_get_keys(well_known_endpoint, cafile)
 
   local decoded_keys = {}
   for i, key in ipairs(keys) do
-      decoded_keys[i] = jwt_decoder:base64_decode(key)
+      decoded_keys[i] = custom_base64_decode(key)
   end
 
   kong.log.debug('Number of keys retrieved: ' .. table.getn(decoded_keys))


### PR DESCRIPTION
Fix for breaking change in Kong 3.5.0 jwt_parser where they switch the from ngx.decode_base64 ngx.base64.decode_base64url and no keys were being found in jwk public keys url.