### PR TITLE
handle token headers without bearer string

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -1,6 +1,5 @@
 local constants = require "kong.constants"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
-local kong_meta = require "kong.meta"
 
 local socket = require "socket"
 local keycloak_keys = require("kong.plugins.jwt-keycloak.keycloak_keys")
@@ -23,7 +22,7 @@ end
 kong.log.debug('JWT_KEYCLOAK_PRIORITY: ' .. priority)
 
 local JwtKeycloakHandler = {
-  VERSION = kong_meta.version,
+  VERSION = "1.3.0",
   PRIORITY = priority,
 }
 


### PR DESCRIPTION
Hi!

When used with [revomatico/kong-oidc](https://github.com/revomatico/kong-oidc) without Authorization bearer token, request failed.

This MR change the behavior of this plugin to remove "bearer" string prefix in token header value only if exists.

Tested with this configuration of kong-oidc that used classic bearer token for non regression:
```yaml
apiVersion: configuration.konghq.com/v1
kind: KongClusterPlugin
metadata:
  name: oidc-sso
  annotations:
    kubernetes.io/ingress.class: kong
plugin: oidc
config:
  client_id: xxxxxxxxxxxxxxxxxx
  client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxx
  discovery: https://mydomain.com/auth/realms/master/.well-known/openid-configuration
  access_token_as_bearer: "yes"
  access_token_header_name: Authorization
```

Also tested without the two `access_token_as_bearer` and `access_token_header_name` that use `X-Access-Token` header without "bearer" string.

For reference, the configuration of jwt-keycloak plugin:
```yaml
apiVersion: configuration.konghq.com/v1
kind: KongClusterPlugin
metadata:
  name: jwt-keycloak-sso
  annotations:
    kubernetes.io/ingress.class: kong
plugin: jwt-keycloak
config:
  cookie_names:
    - cookie_session
  allowed_iss:
    - https://mydomain.com/auth/realms/master
  header_names:
    - X-Access-Token
    - Authorization
  realm_roles:
    - a-role
 ```
